### PR TITLE
Add support for Taskwarrior 2.6 and newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         'License :: OSI Approved :: BSD License',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Intended Audience :: Developers',

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -329,7 +329,7 @@ class TaskWarrior(Backend):
 
     def filter_tasks(self, filter_obj):
         self.enforce_recurrence()
-        args = ['export'] + filter_obj.get_filter_params()
+        args = filter_obj.get_filter_params() + ["export"]
         tasks = []
         for line in self.execute_command(args):
             if line:
@@ -427,8 +427,7 @@ class TaskWarrior(Backend):
             for key, value in data.items():
                 taskfilter.add_filter_param(key, value)
 
-            output = self.execute_command(['export'] +
-                                          taskfilter.get_filter_params())
+            output = self.execute_command(taskfilter.get_filter_params() + ['export'])
 
         # If more than 1 task has been matched still, raise an exception
         if not valid(output):


### PR DESCRIPTION
In 2.6 (currently in development), the syntax for the `export` command got more strict in GothenburgBitFactory/taskwarrior#2576 - the filter expression has to precede the `export` command.