### PR TITLE
Drop compatibility with TW older than 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: python
 env:
-  - TASK_VERSION=v2.1.1
-  - TASK_VERSION=v2.1.2
-  - TASK_VERSION=v2.2.0
-  - TASK_VERSION=v2.3.0
   - TASK_VERSION=v2.4.0
   - TASK_VERSION=v2.4.1
   - TASK_VERSION=v2.4.2
@@ -11,11 +7,14 @@ env:
   - TASK_VERSION=v2.4.4
   - TASK_VERSION=v2.5.0
   - TASK_VERSION=v2.5.1
+  - TASK_VERSION=v2.5.2
+  - TASK_VERSION=v2.5.3
 python:
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install -e .
   - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Requirements
 ------------
 
 * Python 3.5 or above
-* taskwarrior_ v2.1.x or above.
+* taskwarrior_ v2.4.x or above.
 
 Older versions of taskwarrior are untested and may not work.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,13 +4,13 @@ Welcome to tasklib's documentation!
 tasklib is a Python library for interacting with taskwarrior_ databases, using
 a queryset API similar to that of Django's ORM.
 
-Supports Python 3.5 and above, with taskwarrior 2.1.x and above.
+Supports Python 3.5 and above, with taskwarrior 2.4.x and above.
 Older versions of taskwarrior are untested and may not work.
 
 Requirements
 ------------
 
-* taskwarrior_ v2.1.x or above, although newest minor release is recommended.
+* taskwarrior_ v2.4.x or above, although newest minor release is recommended.
 
 Installation
 ------------

--- a/tasklib/backends.py
+++ b/tasklib/backends.py
@@ -84,9 +84,6 @@ class TaskWarriorException(Exception):
 
 class TaskWarrior(Backend):
 
-    VERSION_2_1_0 = '2.1.0'
-    VERSION_2_2_0 = '2.2.0'
-    VERSION_2_3_0 = '2.3.0'
     VERSION_2_4_0 = '2.4.0'
     VERSION_2_4_1 = '2.4.1'
     VERSION_2_4_2 = '2.4.2'
@@ -218,31 +215,17 @@ class TaskWarrior(Backend):
         )
 
     def format_description(self, task):
-        # Task version older than 2.4.0 ignores first word of the
-        # task description if description: prefix is used
-        if self.version < self.VERSION_2_4_0:
-            return task._data['description']
-        else:
-            return "description:'{0}'".format(
-                task._data['description'] or '',
-            )
+        return "description:'{0}'".format(
+            task._data['description'] or '',
+        )
 
     def convert_datetime_string(self, value):
-
-        if self.version >= self.VERSION_2_4_0:
-            # For strings, use 'calc' to evaluate the string to datetime
-            # available since TW 2.4.0
-            args = value.split()
-            result = self.execute_command(['calc'] + args)
-            naive = datetime.datetime.strptime(result[0], DATE_FORMAT_CALC)
-            localized = local_zone.localize(naive)
-        else:
-            raise ValueError(
-                'Provided value could not be converted to '
-                'datetime, its type is not supported: {}'
-                .format(type(value)),
-            )
-
+        # For strings, use 'calc' to evaluate the string to datetime
+        # available since TW 2.4.0
+        args = value.split()
+        result = self.execute_command(['calc'] + args)
+        naive = datetime.datetime.strptime(result[0], DATE_FORMAT_CALC)
+        localized = local_zone.localize(naive)
         return localized
 
     @property
@@ -387,10 +370,6 @@ class TaskWarrior(Backend):
         self.execute_command([task['uuid'], 'stop'])
 
     def complete_task(self, task):
-        # Older versions of TW do not stop active task at completion
-        if self.version < self.VERSION_2_4_0 and task.active:
-            task.stop()
-
         self.execute_command([task['uuid'], 'done'])
 
     def annotate_task(self, task, annotation):


### PR DESCRIPTION
This allows us to drop some workarounds and leverage slightly newer features. The 2.4.0 was released in January 2015.