### PR TITLE
Use new-uuid verbosity token for new task additions

### DIFF
--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1229,21 +1229,21 @@ class DatetimeStringTest(TasklibTest):
         t = Task(self.tw, description='test task', due='eoy')
         now = local_zone.localize(datetime.datetime.now())
         eoy = local_zone.localize(datetime.datetime(
-            year=now.year+1,
-            month=1,
-            day=1,
-            hour=0,
-            minute=0,
-            second=0,
+            year=now.year,
+            month=12,
+            day=31,
+            hour=23,
+            minute=59,
+            second=59,
             ))
-        if self.tw.version < '2.5.2':
+        if self.tw.version >= '2.5.2' and self.tw.version < '2.6.0':
             eoy = local_zone.localize(datetime.datetime(
-                year=now.year,
-                month=12,
-                day=31,
-                hour=23,
-                minute=59,
-                second=59,
+                year=now.year+1,
+                month=1,
+                day=1,
+                hour=0,
+                minute=0,
+                second=0,
                 ))
         self.assertEqual(eoy, t['due'])
 
@@ -1260,23 +1260,23 @@ class DatetimeStringTest(TasklibTest):
         now = local_zone.localize(datetime.datetime.now())
         due_date = local_zone.localize(
             datetime.datetime(
-                year=now.year+1,
-                month=1,
-                day=1,
-                hour=0,
-                minute=0,
-                second=0,
+                year=now.year,
+                month=12,
+                day=31,
+                hour=23,
+                minute=59,
+                second=59,
             )
         ) - datetime.timedelta(0, 4 * 30 * 86400)
-        if self.tw.version < '2.5.2':
+        if self.tw.version >= '2.5.2' and self.tw.version < '2.6.0':
             due_date = local_zone.localize(
                 datetime.datetime(
-                    year=now.year,
-                    month=12,
-                    day=31,
-                    hour=23,
-                    minute=59,
-                    second=59,
+                    year=now.year+1,
+                    month=1,
+                    day=1,
+                    hour=0,
+                    minute=0,
+                    second=0,
                 )
             ) - datetime.timedelta(0, 4 * 30 * 86400)
         self.assertEqual(due_date, t['due'])


### PR DESCRIPTION
The mechanism for obtaining information about newly added task (also called refreshing) was a bit fragile in situations when the only reference to the new task object is an ID number.

In particular, if taskwarrior has some GC cleanup pending, and a new task is added through tasklib, the GC will be performed while exporting the information about the newly added task, thus changing the IDs and rendering the ID reference invalid.

This effect is now mitigated in two ways:
1.) We use the new-uuid (available since 2.4.0) verbosity token, which makes "task add" command output a UUID for the newly added task.
2.) The GC mechanism is disabled during refreshing. This will only be useful if a manual ID reference was used to get a task by the user.

Closes #97.