### PR TITLE
Overload '<' and '>' operators in `LazyUUIDTaskSet`

### DIFF
--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -166,22 +166,16 @@ class LazyUUIDTaskSet(object):
         return self.issuperset(other)
 
     def __lt__(self, other):
-        return self.isstrictsubset(other)
+        return self._uuids < set(t['uuid'] for t in other)
 
     def __gt__(self, other):
-        return self.isstrictsuperset(other)
+        return self._uuids > set(t['uuid'] for t in other)
 
     def issubset(self, other):
         return all([task in other for task in self])
 
     def issuperset(self, other):
         return all([task in self for task in other])
-
-    def isstrictsubset(self, other):
-        return len(set(t['uuid'] for t in other) - self._uuids) > 0
-
-    def isstrictsuperset(self, other):
-        return len(self._uuids - set(t['uuid'] for t in other)) > 0
 
     def union(self, other):
         return LazyUUIDTaskSet(

--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -172,10 +172,10 @@ class LazyUUIDTaskSet(object):
         return self._uuids > set(t['uuid'] for t in other)
 
     def issubset(self, other):
-        return all([task in other for task in self])
+        return self._uuids <= set(t['uuid'] for t in other)
 
     def issuperset(self, other):
-        return all([task in self for task in other])
+        return self._uuids >= set(t['uuid'] for t in other)
 
     def union(self, other):
         return LazyUUIDTaskSet(

--- a/tasklib/lazy.py
+++ b/tasklib/lazy.py
@@ -165,11 +165,23 @@ class LazyUUIDTaskSet(object):
     def __ge__(self, other):
         return self.issuperset(other)
 
+    def __lt__(self, other):
+        return self.isstrictsubset(other)
+
+    def __gt__(self, other):
+        return self.isstrictsuperset(other)
+
     def issubset(self, other):
         return all([task in other for task in self])
 
     def issuperset(self, other):
         return all([task in self for task in other])
+
+    def isstrictsubset(self, other):
+        return len(set(t['uuid'] for t in other) - self._uuids) > 0
+
+    def isstrictsuperset(self, other):
+        return len(self._uuids - set(t['uuid'] for t in other)) > 0
 
     def union(self, other):
         return LazyUUIDTaskSet(

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1245,7 +1245,7 @@ class DatetimeStringTest(TasklibTest):
             hour=23,
             minute=59,
             second=59,
-            ))
+        ))
         if self.tw.version >= '2.5.2' and self.tw.version < '2.6.0':
             eoy = local_zone.localize(datetime.datetime(
                 year=now.year+1,
@@ -1254,7 +1254,7 @@ class DatetimeStringTest(TasklibTest):
                 hour=0,
                 minute=0,
                 second=0,
-                ))
+            ))
         self.assertEqual(eoy, t['due'])
 
     def test_complex_eoy_conversion(self):

--- a/tasklib/tests.py
+++ b/tasklib/tests.py
@@ -1656,6 +1656,70 @@ class LazyUUIDTaskSetTest(TasklibTest):
         lazyset &= taskset
         assert lazyset == set([self.task2])
 
+    def test_le(self):
+        lazyset = LazyUUIDTaskSet(
+            self.tw,
+            (self.task2['uuid'], self.task3['uuid'])
+        )
+        empty_lazyset = LazyUUIDTaskSet(
+            self.tw,
+            [],
+        )
+
+        assert lazyset <= set([self.task1, self.task2, self.task3])
+        assert self.lazy <= set([self.task1, self.task2, self.task3])
+        assert not lazyset <= set([self.task1, self.task2])
+        assert empty_lazyset <= set()
+        assert empty_lazyset <= set([self.task1])
+
+    def test_ge(self):
+        lazyset = LazyUUIDTaskSet(
+            self.tw,
+            (self.task2['uuid'], self.task3['uuid'])
+        )
+        empty_lazyset = LazyUUIDTaskSet(
+            self.tw,
+            [],
+        )
+
+        assert self.lazy >= set([self.task1, self.task2])
+        assert self.lazy >= set([self.task1, self.task2, self.task3])
+        assert not lazyset >= set([self.task1, self.task2])
+        assert empty_lazyset >= set()
+        assert not empty_lazyset >= set([self.task1])
+
+    def test_lt(self):
+        lazyset = LazyUUIDTaskSet(
+            self.tw,
+            (self.task2['uuid'], self.task3['uuid'])
+        )
+        empty_lazyset = LazyUUIDTaskSet(
+            self.tw,
+            [],
+        )
+
+        assert lazyset < set([self.task1, self.task2, self.task3])
+        assert not lazyset < set([self.task2, self.task3])
+        assert not lazyset < set([self.task1, self.task2])
+        assert empty_lazyset < set([self.task1])
+        assert not empty_lazyset < set()
+
+    def test_gt(self):
+        lazyset = LazyUUIDTaskSet(
+            self.tw,
+            (self.task2['uuid'], self.task3['uuid'])
+        )
+        empty_lazyset = LazyUUIDTaskSet(
+            self.tw,
+            [],
+        )
+
+        assert lazyset > set([self.task2])
+        assert not lazyset > set([self.task2, self.task3])
+        assert not lazyset > set([self.task1, self.task2])
+        assert not empty_lazyset > set([self.task1])
+        assert not empty_lazyset > set()
+
 
 class TaskWarriorBackendTest(TasklibTest):
 


### PR DESCRIPTION
In #96 the request was to overload the '<' and '>' operators in `LazyUUIDTaskSet`. I did that in this PR by adding the methods `isstrictsubset` and `isstrictsuperset` to the class.
If I understood the issue correct this was everything that needs to be implemented for that. If I missed something I am happy for a remark.